### PR TITLE
Update README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Manual:
 ~$ npm install ws
 ~$ node Ogar
 ```
-(note: Ubuntu and Debian usually have nodejs packages that require you to execute nodejs Ogar rather than node Ogar.
+(note: Ubuntu and Debian usually have nodejs packages that require you to execute nodejs Ogar rather than node Ogar).
+
 Using the install script:
 ```sh
 ~$ sudo ogar-linux-script.sh install /your/preferred/directory


### PR DESCRIPTION
Some people running Ubuntu and Debian (including me) have been confused as the command for NodeJS is not node, but indeed nodejs. You're welcome to clean this up, (I've never done any of this before, and I'm probably doing something wrong) but please, add some form of this in.

(note: not merging because I want someone to clean that line up for me)
